### PR TITLE
Check for zero div

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1133,7 +1133,10 @@ namespace nodetool
         max_random_index = std::min<uint64_t>(local_peers_count -1, 20);
         random_index = get_random_index_with_fixed_probability(max_random_index);
       } else {
-        random_index = crypto::rand<size_t>() % m_peerlist.get_gray_peers_count();
+        if (m_peerlist.get_gray_peers_count() > 0)
+          random_index = crypto::rand<size_t>() % m_peerlist.get_gray_peers_count();
+        else
+          continue;
       }
 
       CHECK_AND_ASSERT_MES(random_index < local_peers_count, false, "random_starter_index < peers_local.size() failed!!");


### PR DESCRIPTION
When starting seednode with low net node count can result in crash. This fixes that.